### PR TITLE
refactor(grpc): integrate gRPC changes

### DIFF
--- a/pkg/generator/definition.go
+++ b/pkg/generator/definition.go
@@ -9,14 +9,16 @@ import (
 )
 
 type Action struct {
-	Name        string
-	Client      string
-	APICall     APICall  `yaml:"api-call"`
-	Params      []Param  `yaml:"params"`
-	Description string   `yaml:"description"`
-	RootKey     string   `yaml:"root-key"`
-	Identifier  string   `yaml:"identifier"`
-	Fields      []string `yaml:"fields"`
+	Name          string
+	Client        string
+	APICall       APICall  `yaml:"api-call"`
+	Params        []Param  `yaml:"params"`
+	Description   string   `yaml:"description"`
+	RootKey       string   `yaml:"root-key"`
+	Identifier    string   `yaml:"identifier"`
+	IdentifierKey string   `yaml:"identifier-key"`
+	Fields        []string `yaml:"fields"`
+	NoPagination  bool     `yaml:"no-pagination"`
 }
 
 func (action *Action) CanCall() bool {
@@ -61,10 +63,11 @@ func (api *APICall) UnmarshalYAML(value *yaml.Node) error {
 }
 
 type SubcommandDefinition struct {
-	Name        string
-	Actions     map[string]Action `yaml:"actions"`
-	Identifier  string            `yaml:"identifier"`
-	Description string            `yaml:"description"`
+	Name          string
+	Actions       map[string]Action `yaml:"actions"`
+	Identifier    string            `yaml:"identifier"`
+	IdentifierKey string            `yaml:"identifier-key"`
+	Description   string            `yaml:"description"`
 }
 
 type SubcommandMetadata struct {

--- a/pkg/generator/definition/billing-profile.yaml
+++ b/pkg/generator/definition/billing-profile.yaml
@@ -1,4 +1,5 @@
 description: Manage billing profiles for your account
+
 actions:
   list:
     api-call: payment.ListBillingProfiles

--- a/pkg/generator/definition/country.yaml
+++ b/pkg/generator/definition/country.yaml
@@ -1,4 +1,5 @@
 description: Country related actions
+
 actions:
   list:
     api-call: cloud.ListCountries

--- a/pkg/generator/definition/datacenter.yaml
+++ b/pkg/generator/definition/datacenter.yaml
@@ -1,7 +1,9 @@
 description: List or update datacenter colocations
+
 actions:
   list:
     api-call: cloud.ListDatacenters
+    description: List all datacenters
     root-key: Datacenters
     fields:
       - Id
@@ -11,6 +13,7 @@ actions:
 
   update:
     api-call: admin.UpdateDatacenter
+    description: Update a datacenter
     params:
       - name: id
         type: string

--- a/pkg/generator/definition/flavour.yaml
+++ b/pkg/generator/definition/flavour.yaml
@@ -1,4 +1,5 @@
 description: Flavours (images/sizes) the customer can choose from
+
 actions:
   list:
     api-call: admin.ListFlavours

--- a/pkg/generator/definition/image.yaml
+++ b/pkg/generator/definition/image.yaml
@@ -1,7 +1,9 @@
 description: Disk images to boot and install on the nodes
+
 actions:
   list:
     api-call: admin.ListImages
+    description: List all images
     root-key: Images
     fields:
       - Id
@@ -10,12 +12,18 @@ actions:
 
   list-public:
     api-call: cloud.ListPublicImages
+    description: List all public images
     root-key: OperatingSystems
     params:
       - name: flavour_id
         type: string
-        description: Flavour ID
+        description: Flavour ID (deprecated)
         required: true
+      - name: cloud_provider_type
+        type: typev1.CloudProviderType
+        default: typev1.CLOUD_PROVIDER_TYPE_AWS
+        description: Filter by cloud provider type
+        required: false
     fields:
       - Id
       - Name
@@ -23,6 +31,7 @@ actions:
 
   get:
     api-call: admin.GetImage
+    description: Get details for an image
     params:
       - name: id
         type: string
@@ -31,6 +40,7 @@ actions:
 
   update:
     api-call: admin.UpdateImage
+    description: Update image details
     params:
       - name: id
         type: string
@@ -52,7 +62,7 @@ actions:
         type: cloudv1.ImageRelease
         default: cloudv1.IMAGE_RELEASE_STABLE
         description: Release of the image
-        required: false
+        required: true
       - name: name
         type: string
         description: Name of the image
@@ -68,6 +78,7 @@ actions:
 
   create:
     api-call: admin.CreateImage
+    description: Create a new image
     params:
       - name: operating_system_id
         type: string
@@ -97,14 +108,19 @@ actions:
         type: cloudv1.ImageRelease
         default: cloudv1.IMAGE_RELEASE_STABLE
         description: Release of the image
-        required: false
+        required: true
       - name: authentication_types
         type: "[]cloudv1.AuthenticationType"
         description: Authentication types
         required: true
+      - name: contains_spla_license
+        type: bool
+        description: Contains SPLA license
+        required: true
 
   delete:
     api-call: admin.DeleteImage
+    description: Delete an image
     params:
       - name: id
         type: string
@@ -113,6 +129,7 @@ actions:
 
   delete-version:
     api-call: admin.DeleteImageVersion
+    description: Delete an image version
     params:
       - name: id
         type: string

--- a/pkg/generator/definition/ip.yaml
+++ b/pkg/generator/definition/ip.yaml
@@ -1,4 +1,5 @@
 description: IP related actions
+
 actions:
   history:
     api-call: admin.ListIPHistories

--- a/pkg/generator/definition/log.yaml
+++ b/pkg/generator/definition/log.yaml
@@ -1,4 +1,5 @@
 description: Server and admin logs
+
 actions:
   server:
     api-call: admin.ListServerLogs

--- a/pkg/generator/definition/network-arp.yaml
+++ b/pkg/generator/definition/network-arp.yaml
@@ -1,4 +1,5 @@
 description: Network ARP table
+
 actions:
   lookup:
     api-call: admin.LookupARP
@@ -8,3 +9,15 @@ actions:
         type: string
         description: IP address
         required: true
+
+  list:
+    api-call: admin.ListArpEntries
+    description: List all ARP entries
+    root-key: ArpEntries
+    fields:
+      - Status
+    # TODO: Implement Server type to include "Server"
+      - IpAddress
+      - MacAddress
+      - UpdatedAt.Date
+    # TODO: Implement SearchRequest/SearchOptions to include extended_search here

--- a/pkg/generator/definition/network-subnet.yaml
+++ b/pkg/generator/definition/network-subnet.yaml
@@ -1,4 +1,5 @@
 description: Manage subnets
+
 actions:
   delete:
     api-call: admin.DeleteSubnet

--- a/pkg/generator/definition/network-switch.yaml
+++ b/pkg/generator/definition/network-switch.yaml
@@ -1,7 +1,9 @@
 description: Network Switches
+
 actions:
   list:
     api-call: admin.ListSwitches
+    description: List all network switches
     root-key: Switches
     fields:
       - Id
@@ -12,6 +14,7 @@ actions:
 
   get:
     api-call: admin.GetSwitch
+    description: Get switch details for a specific switch
     params:
       - name: id
         type: string

--- a/pkg/generator/definition/network.yaml
+++ b/pkg/generator/definition/network.yaml
@@ -1,7 +1,9 @@
 description: Network management
+
 actions:
   list:
     api-call: admin.ListNetworks
+    description: List all networks
     root-key: Networks
     fields:
       - Id
@@ -17,6 +19,7 @@ actions:
 
   get:
     api-call: admin.GetNetwork
+    description: Get network details
     params:
       - name: id
         type: string
@@ -25,6 +28,7 @@ actions:
 
   create:
     api-call: admin.CreateNetwork
+    description: Create a new network
     params:
       - name: datacenter_id
         type: string
@@ -46,6 +50,7 @@ actions:
 
   update:
     api-call: admin.UpdateNetwork
+    description: Update network details
     params:
       - name: id
         type: string
@@ -62,6 +67,7 @@ actions:
 
   delete:
     api-call: admin.DeleteNetwork
+    description: Delete a network
     params:
       - name: id
         type: string

--- a/pkg/generator/definition/node-agent.yaml
+++ b/pkg/generator/definition/node-agent.yaml
@@ -1,7 +1,9 @@
 description: Agents, which are deployed on the nodes
+
 actions:
   list:
     api-call: admin.ListAgents
+    description: List all agents
     root-key: Agents
     fields:
       - Id
@@ -30,6 +32,7 @@ actions:
 
   delete:
     api-call: admin.DeleteAgent
+    description: Delete an agent
     params:
       - name: id
         type: string

--- a/pkg/generator/definition/node.yaml
+++ b/pkg/generator/definition/node.yaml
@@ -1,3 +1,5 @@
+description: Node related actions
+
 actions:
   list:
     api-call: cloudv2.ListNodes
@@ -14,9 +16,11 @@ actions:
 
   search-options:
     api-call: cloud.GetNodeSearchOptions
+    description: Get search options for nodes
 
   get:
     api-call: cloud.GetNode
+    description: Get details for a node
     identifier: nil
     params:
       - name: id
@@ -168,6 +172,7 @@ actions:
 
   change-billing-period:
     api-call: cloud.ChangeNodeBillingPeriod
+    description: Change the billing period of a node
     params:
       - name: project_id
         type: string

--- a/pkg/generator/definition/operating-systems.yaml
+++ b/pkg/generator/definition/operating-systems.yaml
@@ -1,7 +1,9 @@
-description: Network Switche related operations
+description: Operating system related operations
+
 actions:
   list:
     api-call: admin.ListOperatingSystems
+    description: List all operating systems
     root-key: OperatingSystems
     fields:
       - Id
@@ -10,6 +12,7 @@ actions:
 
   get:
     api-call: admin.GetOperatingSystem
+    description: Get details for an operating system
     params:
       - name: id
         type: string
@@ -18,6 +21,7 @@ actions:
 
   create:
     api-call: admin.CreateOperatingSystem
+    description: Create a new operating system
     params:
       - name: name
         type: string
@@ -27,9 +31,11 @@ actions:
         type: cloudv1.OperatingSystemFamily
         default: cloudv1.OPERATING_SYSTEM_FAMILY_LINUX
         description: Operating system family
+        required: true
 
   update:
     api-call: admin.UpdateOperatingSystem
+    description: Update operating system details
     params:
       - name: id
         type: string
@@ -43,6 +49,7 @@ actions:
         type: cloudv1.OperatingSystemFamily
         default: cloudv1.OPERATING_SYSTEM_FAMILY_LINUX
         description: Operating system family
+        required: true
       - name: default_image_id
         type: string
         description: Default image ID
@@ -54,6 +61,7 @@ actions:
 
   delete:
     api-call: admin.DeleteOperatingSystem
+    description: Delete an operating system
     params:
       - name: id
         type: string

--- a/pkg/generator/definition/project-cloudprovider.yaml
+++ b/pkg/generator/definition/project-cloudprovider.yaml
@@ -1,0 +1,146 @@
+description: Project cloud providers
+
+actions:
+  list:
+    api-call: cloud.ListProjectCloudProviders
+    description: List all cloud providers
+    root-key: CloudProviders
+
+  get:
+    api-call: cloud.GetProjectCloudProvider
+    description: Get cloud provider details
+    params:
+      - name: cloud_provider_id
+        type: string
+        description: Cloud Provider ID
+        required: true
+
+  update:
+    api-call: cloud.UpdateProjectCloudProvider
+    description: Update cloud provider details
+    params:
+      - name: cloud_provider_id
+        type: string
+        description: Cloud Provider ID
+        required: true
+      - name: name
+        type: string
+        description: Cloud Provider name
+        required: false
+      - name: region
+        type: string
+        description: Cloud Provider region
+        required: true
+      - name: api_key_id
+        type: string
+        description: Cloud Provider API Key ID
+        required: true
+      - name: api_key_secret
+        type: string
+        description: Cloud Provider API Key Secret
+        required: true
+
+  create:
+    api-call: cloud.CreateProjectCloudProvider
+    description: Create a new cloud provider
+    params:
+      - name: name
+        type: string
+        description: Cloud Provider name
+        required: true
+      - name: type
+        type: typev1.CloudProviderType
+        default: typev1.CLOUD_PROVIDER_TYPE_AWS
+        description: Cloud Provider type
+        required: true
+      - name: api_key_id
+        type: string
+        description: Cloud Provider API Key ID
+        required: true
+      - name: api_key_secret
+        type: string
+        description: Cloud Provider API Key Secret
+        required: true
+      - name: region
+        type: string
+        description: Cloud Provider region
+        required: true
+
+  delete:
+    api-call: cloud.DeleteProjectCloudProvider
+    description: Delete a cloud provider
+    params:
+      - name: cloud_provider_id
+        type: string
+        description: Cloud Provider ID
+        required: true
+
+  import:
+    api-call: cloud.ImportProjectCloudProviderResource
+    description: Import cloud provider resources
+    params:
+      - name: cloud_provider_id
+        type: string
+        description: Cloud Provider ID
+        required: true
+      - name: resource_id
+        type: string
+        description: Resource ID
+        required: true
+
+  list-resources:
+    api-call: cloud.ListProjectCloudProviderResources
+    description: List all cloud provider resources
+    root-key: Resources
+    params:
+      - name: cloud_provider_id
+        type: string
+        description: Cloud Provider ID
+        required: true
+
+  # TODO: Implement custom response type first
+  list-images:
+    api-call: admin.ListCloudProviderImages
+    description: List all cloud provider images
+    root-key: CloudProviderImages
+    no-pagination: true
+    identifier: nil
+    params:
+      - name: image_id
+        type: string
+        description: Cloud Provider ID
+        required: true
+
+  add-image:
+    api-call: admin.AddCloudProviderImage
+    description: Add a new image to cloud provider
+    identifier: nil
+    params:
+      - name: image_id
+        type: string
+        description: Cloud Provider image ID
+        required: true
+      - name: cloud_provider_type
+        type: typev1.CloudProviderType
+        default: typev1.CLOUD_PROVIDER_TYPE_AWS
+        description: Cloud Provider type
+        required: true
+      - name: cloud_provider_image_id
+        type: string
+        description: Cloud Provider image ID
+        required: true
+
+  delete-image:
+    api-call: admin.DeleteCloudProviderImage
+    description: Delete an image from cloud provider
+    identifier: nil
+    params:
+      - name: image_id
+        type: string
+        description: Cloud Provider image ID
+        required: true
+
+
+
+identifier: session.CurrentProject
+identifier-key: ProjectId

--- a/pkg/generator/definition/project-image.yaml
+++ b/pkg/generator/definition/project-image.yaml
@@ -1,11 +1,19 @@
-description: Project Images
+description: Project images
+
 actions:
   list:
     api-call: cloud.ListProjectImages
+    description: List all images in the project
     root-key: Images
+    params:
+      - name: only_available
+        type: bool
+        description: Only list available images
+        required: false
 
   get:
     api-call: cloud.GetProjectImage
+    description: Get project image details
     identifier: nil
     params:
       - name: id
@@ -36,6 +44,7 @@ actions:
 
   delete:
     api-call: cloud.DeleteProjectImage
+    description: Delete an project image
     identifier: nil
     params:
       - name: id
@@ -49,6 +58,7 @@ actions:
 
   delete-version:
     api-call: cloud.DeleteProjectImageVersion
+    description: Delete an project image version
     identifier: nil
     params:
       - name: id

--- a/pkg/generator/definition/project.yaml
+++ b/pkg/generator/definition/project.yaml
@@ -1,6 +1,9 @@
+description: Project related actions
+
 actions:
   list:
     api-call: cloud.ListProjects
+    description: List all projects
     identifier: nil
     root-key: Projects
     fields:
@@ -12,6 +15,7 @@ actions:
 
   get:
     api-call: cloud.GetProject
+    description: Get details for a project
     identifier: nil
     params:
       - name: id
@@ -22,6 +26,7 @@ actions:
   # TODO: Fix after dependency upgrade
   update:
     api-call: cloud.UpdateProject
+    description: Update project details
     params:
       - name: name
         type: string
@@ -67,6 +72,7 @@ actions:
 
   delete:
     api-call: cloud.DeleteProject
+    description: Delete a project
     identifier: nil
     params:
       - name: id
@@ -76,6 +82,7 @@ actions:
 
   flavours:
     api-call: cloud.ListProjectFlavours
+    description: List all flavours in the project
     params:
       - name: datacenter_id
         description: Datacenter to fetch the flavours from
@@ -90,6 +97,7 @@ actions:
 
   networks:
     api-call: admin.ListProjectNetworks
+    description: List all networks in the project
 
   # network-create is implemented in code, because it is a special case
   # where we need to create a network and then attach it to the project.
@@ -98,6 +106,7 @@ actions:
 
   logs:
     api-call: cloudv2.ListProjectLogs
+    description: List all logs in the project
     fields:
       - CreatedAt.DateTime
       - User.BasicUser
@@ -106,6 +115,7 @@ actions:
   # Join/Leave project
   join:
     api-call: cloud.JoinProject
+    description: Join a project
     params:
       - name: accept
         type: bool
@@ -113,9 +123,11 @@ actions:
 
   leave:
     api-call: cloud.LeaveProject
+    description: Leave a project
 
   invite-member:
     api-call: cloud.InviteMemberToProject
+    description: Invite a member to the project
     identifier: nil
     params:
       - name: id
@@ -129,6 +141,7 @@ actions:
 
   remove-member:
     api-call: cloud.RemoveMemberFromProject
+    description: Remove a member from the project
     params:
       - name: user_id
         type: string
@@ -136,6 +149,7 @@ actions:
 
   default-project:
     api-call: cloud.ChangeDefaultProject
+    description: Change the default project
     identifier: nil
     params:
       - name: id
@@ -150,6 +164,7 @@ actions:
 
   usage:
     api-call: cloud.GetProjectUsage
+    description: Get project usage
     params:
       - name: detailed
         type: bool
@@ -157,10 +172,12 @@ actions:
 
   images:
     api-call: cloud.ListProjectImages
+    description: List all images in the project
 
   # TODO: Custom formatter to output keys in authorized_keys format
   ssh-keys:
     api-call: cloud.ListProjectSSHKeys
+    description: List all SSH keys in the project
     root-key: Keys
     fields:
       - User.BasicUser

--- a/pkg/generator/definition/region.yaml
+++ b/pkg/generator/definition/region.yaml
@@ -1,7 +1,9 @@
 description: Manage regions in which datacenters are located
+
 actions:
   list:
     api-call: admin.ListRegions
+    description: List all regions
     root-key: Regions
     fields:
       - Id
@@ -10,6 +12,7 @@ actions:
 
   get:
     api-call: admin.GetRegion
+    description: Get details for a region
     params:
       - name: id
         type: string

--- a/pkg/generator/definition/server-pool.yaml
+++ b/pkg/generator/definition/server-pool.yaml
@@ -1,4 +1,5 @@
 description: Server Pools
+
 actions:
   list:
     api-call: admin.ListServerPools

--- a/pkg/generator/definition/server.yaml
+++ b/pkg/generator/definition/server.yaml
@@ -1,4 +1,5 @@
 description: Physical servers
+
 actions:
   list:
     api-call: admin.ListServers

--- a/pkg/generator/definition/spla.yaml
+++ b/pkg/generator/definition/spla.yaml
@@ -1,4 +1,6 @@
 description: SPLA Reporting
+
 actions:
   get:
     api-call: admin.GetSplaReporting
+    description: Get SPLA reporting details

--- a/pkg/generator/definition/sshkey.yaml
+++ b/pkg/generator/definition/sshkey.yaml
@@ -1,11 +1,14 @@
-description: SSH Keys
+description: SSH Key management
+
 actions:
   list:
     api-call: cloud.ListUserSSHKeys
+    description: List all SSH keys
     root-key: SshKeys
 
   list-project:
     api-call: cloud.ListProjectSSHKeys
+    description: List all SSH keys in the project
     root-key: Keys
     params:
       - name: id
@@ -28,6 +31,7 @@ actions:
 
   delete:
     api-call: cloud.DeleteUserSSHKey
+    description: Delete an SSH key
     params:
       - name: id
         type: string

--- a/pkg/generator/definition/timezone.yaml
+++ b/pkg/generator/definition/timezone.yaml
@@ -1,11 +1,14 @@
 description: Timezones
+
 actions:
   list:
     api-call: cloud.ListTimezones
+    description: List all timezones
     root-key: Timezones
 
   update:
     api-call: cloud.UpdateTimezone
+    description: Update a timezone
     params:
       - name: timezone
         type: string

--- a/pkg/generator/definition/user.yaml
+++ b/pkg/generator/definition/user.yaml
@@ -1,9 +1,9 @@
 description: User management
+
 actions:
   ssh-keys:
     api-call: cloud.ListUserSSHKeys
-    response-type: "*typev1.SSHKey"
-    no-pagination: true
+    description: List all SSH keys for a user
     fields:
       - Name
       - Type
@@ -25,6 +25,7 @@ actions:
       - Confirmed
       - Locked
       - NodeLimit
+      - DefaultPlanCode
       - Type
       - LastLoginAt
 

--- a/pkg/generator/helpers.go
+++ b/pkg/generator/helpers.go
@@ -280,7 +280,11 @@ func stripEnum(s string) string {
 }
 
 func clientPackageName(s string) string {
-	return "buf.build/gen/go/gportal/gpcore/protocolbuffers/go/gpcore/api/" + stripClient(s) + "/v" + stripVersion(s)
+	apiPrefix := "api/" + stripClient(s)
+	if stripClient(s) == "type" {
+		apiPrefix = "type"
+	}
+	return "buf.build/gen/go/gportal/gpcore/protocolbuffers/go/gpcore/" + apiPrefix + "/v" + stripVersion(s)
 }
 
 func stripVersion(s string) string {


### PR DESCRIPTION
Integrate and add/change all gRPC changes since 6/2024 into the commandline tool. To support List* endpoints, which do not return a pagination response, a new action flag is introduced ("no-pagination"). This way, missing gRPC endpoints can be integrated. For some endpoints, the identifier is not called "Id", so there is another field ("identifier-key") to define a different key for the identifier. Further, all definitions where updated and descriptions added.

* New action field "identifier-key"
* New global field "identifier-key"
* New action field "no-pagination"
* All definitions got descriptions
* gRPC changes since 6/2024 are added/changed