### PR TITLE
ci(release): make next the prerelease branch

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,12 +1,12 @@
 {
   "branches": [
     {
-      "name": "dev",
-      "prerelease": true
-    },
-    {
       "name": "main",
       "prerelease": false
+    },
+    {
+      "name": "next",
+      "prerelease": true
     }
   ],
   "plugins": [


### PR DESCRIPTION
The preview branch is now 'next' (the GitHub default), not the unused 'dev' branch which no longer exists. Configure semantic-release so 'main' cuts production releases and 'next' cuts prereleases for testing before going to production.